### PR TITLE
Multi arch build arm32 and arm64 - clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,0 +1,42 @@
+FROM alpine AS qemu
+
+# Download QEMU, see https://github.com/docker/hub-feedback/issues/1261
+ENV QEMU_URL https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-arm.tar.gz
+RUN apk add curl && curl -L ${QEMU_URL} | tar zxvf - -C . --strip-components 1
+
+
+FROM arm64v8/alpine:3.12 as builder
+
+# Add QEMU
+COPY --from=qemu qemu-arm-static /usr/bin
+
+LABEL maintainer="knthmn@outlook.com"
+ARG RCLONE_VERSION=v1.52.3
+ARG BORGMATIC_VERSION=1.5.10
+RUN apk add \
+    py3-pip \
+    && pip3 install borgmatic==${BORGMATIC_VERSION} \
+    && cd /tmp \
+    && wget -q https://downloads.rclone.org/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-arm64.zip \
+    && unzip -q rclone*.zip \
+    && cd rclone-*-linux-arm64 \
+    && cp rclone /usr/bin \
+    && chmod 755 /usr/bin/rclone
+
+FROM arm64v8/alpine:3.12
+LABEL maintainer="knthmn@outlook.com"
+RUN apk add --no-cache \
+    borgbackup \
+    tzdata
+COPY --from=builder /usr/lib/python3.8/site-packages /usr/lib/python3.8/
+COPY --from=builder \ 
+    /usr/bin/borgmatic \
+    /usr/bin/rclone \
+    /usr/bin/
+COPY entry.py script.py /
+
+ENV BORG_CACHE_DIR=/mnt/borg_cache
+ENV BORG_CONFIG_DIR=/mnt/borg_config
+VOLUME [ "/mnt/source", "/mnt/repo", "/mnt/rclone_config", "/mnt/borgmatic", "/mnt/borg_cache", "/mnt/borg_config" ]
+
+ENTRYPOINT ["/usr/bin/python3", "-u", "/entry.py"]

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -5,25 +5,28 @@ ENV QEMU_URL https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/
 RUN apk add curl && curl -L ${QEMU_URL} | tar zxvf - -C . --strip-components 1
 
 
-FROM arm64v8/alpine:3.12 as builder
+FROM arm32v7/alpine:3.12 as builder
 
 # Add QEMU
 COPY --from=qemu qemu-arm-static /usr/bin
 
 LABEL maintainer="knthmn@outlook.com"
-ARG RCLONE_VERSION=v1.52.3
+ARG RCLONE_VERSION=v1.53.3
 ARG BORGMATIC_VERSION=1.5.10
 RUN apk add \
     py3-pip \
     && pip3 install borgmatic==${BORGMATIC_VERSION} \
     && cd /tmp \
-    && wget -q https://downloads.rclone.org/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-arm64.zip \
+    && wget -q https://downloads.rclone.org/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-arm-v7.zip \
     && unzip -q rclone*.zip \
-    && cd rclone-*-linux-arm64 \
+    && cd rclone-*-linux-arm-v7 \
     && cp rclone /usr/bin \
     && chmod 755 /usr/bin/rclone
 
-FROM arm64v8/alpine:3.12
+FROM arm32v7/alpine:3.12
+# Add QEMU
+COPY --from=qemu qemu-arm-static /usr/bin
+
 LABEL maintainer="knthmn@outlook.com"
 RUN apk add --no-cache \
     borgbackup \

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,0 +1,42 @@
+FROM alpine AS qemu
+
+# Download QEMU, see https://github.com/docker/hub-feedback/issues/1261
+ENV QEMU_URL https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-arm.tar.gz
+RUN apk add curl && curl -L ${QEMU_URL} | tar zxvf - -C . --strip-components 1
+
+
+FROM arm32v7/alpine:3.12 as builder
+
+# Add QEMU
+COPY --from=qemu qemu-arm-static /usr/bin
+
+LABEL maintainer="knthmn@outlook.com"
+ARG RCLONE_VERSION=v1.52.3
+ARG BORGMATIC_VERSION=1.5.10
+RUN apk add \
+    py3-pip \
+    && pip3 install borgmatic==${BORGMATIC_VERSION} \
+    && cd /tmp \
+    && wget -q https://downloads.rclone.org/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-arm-v7.zip \
+    && unzip -q rclone*.zip \
+    && cd rclone-*-linux-arm-v7 \
+    && cp rclone /usr/bin \
+    && chmod 755 /usr/bin/rclone
+
+FROM arm32v7/alpine:3.12
+LABEL maintainer="knthmn@outlook.com"
+RUN apk add --no-cache \
+    borgbackup \
+    tzdata
+COPY --from=builder /usr/lib/python3.8/site-packages /usr/lib/python3.8/
+COPY --from=builder \ 
+    /usr/bin/borgmatic \
+    /usr/bin/rclone \
+    /usr/bin/
+COPY entry.py script.py /
+
+ENV BORG_CACHE_DIR=/mnt/borg_cache
+ENV BORG_CONFIG_DIR=/mnt/borg_config
+VOLUME [ "/mnt/source", "/mnt/repo", "/mnt/rclone_config", "/mnt/borgmatic", "/mnt/borg_cache", "/mnt/borg_config" ]
+
+ENTRYPOINT ["/usr/bin/python3", "-u", "/entry.py"]

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,29 +1,32 @@
 FROM alpine AS qemu
 
 # Download QEMU, see https://github.com/docker/hub-feedback/issues/1261
-ENV QEMU_URL https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-arm.tar.gz
+ENV QEMU_URL https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz
 RUN apk add curl && curl -L ${QEMU_URL} | tar zxvf - -C . --strip-components 1
 
 
-FROM arm32v7/alpine:3.12 as builder
+FROM arm64v8/alpine:3.12 as builder
 
 # Add QEMU
-COPY --from=qemu qemu-arm-static /usr/bin
+COPY --from=qemu qemu-aarch64-static /usr/bin
 
 LABEL maintainer="knthmn@outlook.com"
-ARG RCLONE_VERSION=v1.52.3
+ARG RCLONE_VERSION=v1.53.3
 ARG BORGMATIC_VERSION=1.5.10
 RUN apk add \
     py3-pip \
     && pip3 install borgmatic==${BORGMATIC_VERSION} \
     && cd /tmp \
-    && wget -q https://downloads.rclone.org/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-arm-v7.zip \
+    && wget -q https://downloads.rclone.org/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-arm64.zip \
     && unzip -q rclone*.zip \
-    && cd rclone-*-linux-arm-v7 \
+    && cd rclone-*-linux-arm64 \
     && cp rclone /usr/bin \
     && chmod 755 /usr/bin/rclone
 
-FROM arm32v7/alpine:3.12
+FROM arm64v8/alpine:3.12
+# Add QEMU
+COPY --from=qemu qemu-aarch64-static /usr/bin
+
 LABEL maintainer="knthmn@outlook.com"
 RUN apk add --no-cache \
     borgbackup \

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Use manifest-tool to create the manifest, given the experimental
+# "docker manifest" command isn't available yet on Docker Hub.
+
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v0.9.0/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+./manifest-tool push from-spec multi-arch-manifest.yml

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker run --rm --privileged multiarch/qemu-user-static:register --reset

--- a/multi-arch-manifest.yml
+++ b/multi-arch-manifest.yml
@@ -1,0 +1,16 @@
+image: sspeiser/borgmatic-rclone:latest
+manifests:
+  - image: sspeiser/borgmatic-rclone:latest-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  - image: sspeiser/borgmatic-rclone:latest-arm64v8
+    platform:
+      architecture: arm64
+      os: linux
+      variant: v8
+  - image: sspeiser/borgmatic-rclone:latest-arm32v7
+    platform:
+      architecture: arm
+      os: linux
+      variant: v7


### PR DESCRIPTION
Hi this is the updated pull request, where I removed the usage of the most current versions. I had to update the rclone version as it was not available for arm v7 in a correctly named download package. In the meantime it runs quite good on my Raspberry Pi 4.

-- 

Hi, thanks for that great docker image! I adapted it to also build for arm32 and arm64. Loosely following https://github.com/ckulka/docker-multi-arch-example
Maybe this can be useful for you.
Major disclaimer: It runs on my Jetson Nano but no real productive testing yet.

To do automated builds on Docker Hub the configurations must be updated:

![](https://user-images.githubusercontent.com/58770337/99988716-21d57d00-2db2-11eb-8614-7cbd367b550e.png)
