### PR TITLE
Only prune and check in create task; check only in explicit check task

### DIFF
--- a/script.py
+++ b/script.py
@@ -20,7 +20,7 @@ try:
     if task == 'create':
         rclone_destination = os.environ['DESTINATION']
         rclone_args = os.environ.get('RCLONE_ARGS', '--fast-list --delete-after --delete-excluded')
-        subprocess.run('borgmatic -c /mnt/borgmatic -v 1', shell=True, check=True)
+        subprocess.run('borgmatic -p -C -c /mnt/borgmatic -v 1', shell=True, check=True)
         subprocess.run(f'rclone sync /mnt/repo {rclone_destination} --config /mnt/rclone_config/rclone.conf --stats-log-level NOTICE --stats-one-line {rclone_args}', shell=True, check=True)
     elif task == 'check':
         check_options = os.environ.get('CHECK_OPTS', '')


### PR DESCRIPTION
The create task in script.py is calling borgmatic with no action which means it does: prune, create, check.
Check takes very long time and so I think we should be able to separate it from creation. The script already has a explicit check task that. So I removed it from create. 
Alternativ would be to create a new task 'createWithoutCheck' or similar.